### PR TITLE
Fixing small bug

### DIFF
--- a/LinkedList.h
+++ b/LinkedList.h
@@ -169,7 +169,7 @@ bool LinkedList<T>::add(int index, T _t){
 	// if(index == 0)
 	// 	return shift(_t);
 
-	if(index > _size)
+	if(index >= _size)
 		return add(_t);
 
 	ListNode<T> *tmp = new ListNode<T>(),


### PR DESCRIPTION
This is small but annoying. If you type `add(0, element);` you are going to add `T()` instead of `element`.
