### PR TITLE
fixed unshift: root reset

### DIFF
--- a/LinkedList.h
+++ b/LinkedList.h
@@ -216,6 +216,7 @@ bool LinkedList<T>::unshift(T _t){
 	ListNode<T> *tmp = new ListNode<T>();
 	tmp->next = root;
 	tmp->data = _t;
+	root = tmp;
 	
 	_size++;
 	isCached = false;


### PR DESCRIPTION
Now the `root` pointer is actually set to the new head node. Previously there was an annoying bug that meant the `LinkedList` never actually had any nodes added on with `unshift()`.
