### PR TITLE
Fix invalid default value specification

### DIFF
--- a/LinkedList.h
+++ b/LinkedList.h
@@ -85,7 +85,7 @@ public:
 		Return Element if accessible,
 		else, return false;
 	*/
-	virtual T get(int index, bool useCached);
+	virtual T get(int index);
 
 	/*
 		Clear the entire array
@@ -308,7 +308,7 @@ T LinkedList<T>::remove(int index){
 
 
 template<typename T>
-T LinkedList<T>::get(int index, bool useCached = false){
+T LinkedList<T>::get(int index){
 	ListNode<T> *tmp = getNode(index);
 
 	return (tmp ? tmp->data : T());


### PR DESCRIPTION
The default value should be present in the declaration, not the definition.

This caused a compilation error on GCC 4.9.2.