### PR TITLE
Remove pointer type converting warnings

### DIFF
--- a/LinkedList.h
+++ b/LinkedList.h
@@ -98,8 +98,8 @@ public:
 template<typename T>
 LinkedList<T>::LinkedList()
 {
-	root=false;
-	last=false;
+	root=NULL;
+	last=NULL;
 	_size=0;
 
 	lastNodeGot = root;
@@ -112,13 +112,13 @@ template<typename T>
 LinkedList<T>::~LinkedList()
 {
 	ListNode<T>* tmp;
-	while(root!=false)
+	while(root!=NULL)
 	{
 		tmp=root;
 		root=root->next;
 		delete tmp;
 	}
-	last = false;
+	last = NULL;
 	_size=0;
 	isCached = false;
 }
@@ -189,7 +189,7 @@ bool LinkedList<T>::add(T _t){
 
 	ListNode<T> *tmp = new ListNode<T>();
 	tmp->data = _t;
-	tmp->next = false;
+	tmp->next = NULL;
 	
 	if(root){
 		// Already have elements inserted
@@ -245,7 +245,7 @@ T LinkedList<T>::pop(){
 		ListNode<T> *tmp = getNode(_size - 2);
 		T ret = tmp->next->data;
 		delete(tmp->next);
-		tmp->next = false;
+		tmp->next = NULL;
 		last = tmp;
 		_size--;
 		return ret;
@@ -253,8 +253,8 @@ T LinkedList<T>::pop(){
 		// Only one element left on the list
 		T ret = root->data;
 		delete(root);
-		root = false;
-		last = false;
+		root = NULL;
+		last = NULL;
 		_size = 0;
 		return ret;
 	}

--- a/LinkedList.h
+++ b/LinkedList.h
@@ -13,6 +13,8 @@
 #ifndef LinkedList_h
 #define LinkedList_h
 
+#include <stddef.h>
+
 template<class T>
 struct ListNode
 {


### PR DESCRIPTION
I do not see the build failures mentioned in #12 with Arduino IDE 1.6.9 when building for the Uno or Zero.

However, I see the following warnings when `Show verbose output during: [*] compilation` is checked in the IDE preferences:

```
In file included from /var/folders/m9/y22yzb0d49x_kws_6jtwdphw0000gn/T/arduino_modified_sketch_235/SimpleIntegerList.pde:11:0:
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h: In instantiation of 'LinkedList<T>::LinkedList() [with T = int]':
/var/folders/m9/y22yzb0d49x_kws_6jtwdphw0000gn/T/arduino_modified_sketch_235/SimpleIntegerList.pde:13:42:   required from here
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h:101:6: warning: converting 'false' to pointer type 'ListNode<int>*' [-Wconversion-null]
  root=false;
      ^
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h:102:6: warning: converting 'false' to pointer type 'ListNode<int>*' [-Wconversion-null]
  last=false;
      ^
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h: In instantiation of 'LinkedList<T>::~LinkedList() [with T = int]':
/var/folders/m9/y22yzb0d49x_kws_6jtwdphw0000gn/T/arduino_modified_sketch_235/SimpleIntegerList.pde:13:42:   required from here
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h:121:7: warning: converting 'false' to pointer type 'ListNode<int>*' [-Wconversion-null]
  last = false;
       ^
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h: In instantiation of 'bool LinkedList<T>::add(T) [with T = int]':
/var/folders/m9/y22yzb0d49x_kws_6jtwdphw0000gn/T/arduino_modified_sketch_235/SimpleIntegerList.pde:26:14:   required from here
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h:192:12: warning: converting 'false' to pointer type 'ListNode<int>*' [-Wconversion-null]
  tmp->next = false;
            ^
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h: In instantiation of 'T LinkedList<T>::pop() [with T = int]':
/var/folders/m9/y22yzb0d49x_kws_6jtwdphw0000gn/T/arduino_modified_sketch_235/SimpleIntegerList.pde:56:1:   required from here
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h:248:13: warning: converting 'false' to pointer type 'ListNode<int>*' [-Wconversion-null]
   tmp->next = false;
             ^
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h:256:8: warning: converting 'false' to pointer type 'ListNode<int>*' [-Wconversion-null]
   root = false;
        ^
/Users/smistry/Documents/Arduino/libraries/LinkedList/LinkedList.h:257:8: warning: converting 'false' to pointer type 'ListNode<int>*' [-Wconversion-null]
   last = false;
```

This change removes them, and will probably also solve #12.