### PR TITLE
Fix bug in unshift

### DIFF
--- a/LinkedList.h
+++ b/LinkedList.h
@@ -224,6 +224,7 @@ bool LinkedList<T>::unshift(T _t){
 
 	ListNode<T> *tmp = new ListNode<T>();
 	tmp->next = root;
+	root->prev = tmp;
 	tmp->data = _t;
 	root = tmp;
 	


### PR DESCRIPTION
Set prev on old root in `unshift`.  Using `unshift` on a non-empty list didn't update the previous pointer of the old root to the newly added node.