### PR TITLE
Return nullptr instead of false in getNode

### DIFF
--- a/LinkedList.h
+++ b/LinkedList.h
@@ -164,7 +164,7 @@ ListNode<T>* LinkedList<T>::getNode(int index){
 		return current;
 	}
 
-	return false;
+	return nullptr;
 }
 
 template<typename T>


### PR DESCRIPTION
Resolves #16 and gets rid of the compiler warning.