### PR TITLE
getNode() --> return NULL pointer instead of bool "false"

### DIFF
--- a/LinkedList.h
+++ b/LinkedList.h
@@ -164,7 +164,7 @@ ListNode<T>* LinkedList<T>::getNode(int index){
 		return current;
 	}
 
-	return false;
+	return NULL;
 }
 
 template<typename T>


### PR DESCRIPTION
When compiling with this library I noticed a warning complaining about
a "false" being typecast as a pointer and tracked it down.  It looks
like this was just a typo, and it should be returning a NULL pointer
instead.  After I replaced it with NULL, the warnings went away and
from what I can tell everything is working just as expected.

FWIW the warning was:

n file included from /home/cmooney/installs/arduino-1.8.5/libraries/LaserMessaging/LaserMessaging.h:6:0,
                 from /home/cmooney/installs/arduino-1.8.5/libraries/LaserMessaging/LaserMessaging.cpp:1:
                 /home/cmooney/installs/arduino-1.8.5/libraries/LinkedList/LinkedList.h: In instantiation of 'ListNode<T>* LinkedList<T>::getNode(int) [with T = unsigned int]':
                 /home/cmooney/installs/arduino-1.8.5/libraries/LinkedList/LinkedList.h:308:38:   required from 'T LinkedList<T>::remove(int) [with T = unsigned int]'
                 /home/cmooney/installs/arduino-1.8.5/libraries/LaserMessaging/LaserMessaging.cpp:235:25:   required from here
                 /home/cmooney/installs/arduino-1.8.5/libraries/LinkedList/LinkedList.h:167:9: warning: converting 'false' to pointer type 'ListNode<unsigned int>*' [-Wconversion-null]
                   return false;
                            ^

This CL just changes that "false" to a "NULL" and makes no other changes.

Signed-off-by: Charlie Mooney <cmooney3@gmail.com>