### PR TITLE
Avoid tests being compiled by Arduino build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With a simple but powerful caching algorithm, you can get subsequent objects muc
 
 ## Tests
 
-`cd` to this directory and run `g++ -std=c++14 tests.cpp -o tests && ./tests`
+`cd` to this directory and run `g++ -std=c++14 extras/test/tests.cpp -o tests && ./tests`
 
 -------------------------
 

--- a/extras/test/tests.cpp
+++ b/extras/test/tests.cpp
@@ -1,6 +1,6 @@
 //g++ -std=c++14 tests.cpp -o tests && ./tests
 
-#include "LinkedList.h"
+#include "../../LinkedList.h"
 #include <assert.h> 
 #include <iostream>
 


### PR DESCRIPTION
The placement of the tests program in the root of the library caused it to be compiled by the Arduino build system, which
causes serious problems:

- Compilation fails for boards whose toolchain doesn't provide iostream ("iostream: No such file or directory")
- When compilation doesn't fail, the test `main()` overrides the Arduino core library's `main()`, completely nuking the user's sketch.  On MCUs with native USB (e.g., ATSAMD21G18), this includes the USB CDC code that provides a serial port for uploads on native USB MCUs (e.g., ATSAMD21G18), soft bricking the board.

The new location for the file is fairly standardized. For example:
https://github.com/arduino-libraries/ArduinoIoTCloud/tree/master/extras/test
The `extras` folder is intended to be a place to put things that should be ignored by the Arduino development software and build system:
https://arduino.github.io/arduino-cli/latest/library-specification/#extra-documentation

- Fixes https://github.com/ivanseidel/LinkedList/issues/44
- Fixes https://github.com/ivanseidel/LinkedList/issues/39
- Fixes https://github.com/ivanseidel/LinkedList/issues/36