### PR TITLE
Add wrapper namespace to workaround Async Webserver Class name collision

### DIFF
--- a/LList.h
+++ b/LList.h
@@ -14,9 +14,15 @@
     include it instead of <LinkedList.h> and use Class types - LList, LNode
 */
 
+#ifndef LList_h
+#define LList_h
+#include <iterator>
+
 namespace LL{ 
 #include <LinkedList.h>
 }
 
+
 template<typename T> using LNode = LL::ListNode<T>;
 template<typename T> using LList = LL::LinkedList<T>;
+#endif

--- a/LList.h
+++ b/LList.h
@@ -1,0 +1,22 @@
+/*
+	LinkedList.h - V1.1 - Generic LinkedList implementation
+	Works better with FIFO, because LIFO will need to
+	search the entire List to find the last one;
+
+	For instructions, go to https://github.com/ivanseidel/LinkedList
+
+	Created by Ivan Seidel Gomes, March, 2013.
+	Released into the public domain.
+*/
+
+/*
+    This is a namespace wrapper to avoid collision with ESP Async WebServer's LinkedList class
+    include it instead of <LinkedList.h> and use Class types - LList, LNode
+*/
+
+namespace LL{ 
+#include <LinkedList.h>
+}
+
+template<typename T> using LNode = LL::ListNode<T>;
+template<typename T> using LList = LL::LinkedList<T>;


### PR DESCRIPTION
No need to rename lib/class. Could be used in projects with Async server by using wrapper name.

Closes #40, superseeds #41